### PR TITLE
Append url only if defined

### DIFF
--- a/modules/__tests__/base-test.js
+++ b/modules/__tests__/base-test.js
@@ -9,4 +9,10 @@ describe('base', () => {
       expect(url).toEqual('https://api.stripe.com/customers')
     )
   )
+
+  it('sets and uses the base URL of the request if no URI is provided', () =>
+    base('https://api.stripe.com/customers')(echo).then(({ url }) =>
+      expect(url).toEqual('https://api.stripe.com/customers')
+    )
+  )
 })

--- a/modules/index.js
+++ b/modules/index.js
@@ -79,7 +79,7 @@ export const accept = (contentType) =>
  */
 export const base = (baseURL) =>
   (fetch, url, options) =>
-    fetch(baseURL + url, options)
+    fetch(baseURL + (url || ''), options)
 
 /**
  * Adds the given object to the query string in the request.


### PR DESCRIPTION
This is a small fix that happens when you create a fetch function but not pass any URI string because the URL is already defined in `base`.

In other words:

```js
import httpClient from 'http-client'

const createFooBar = httpClient.createFetch(
  httpClient.accept('application/json'),
  httpClient.header('Content-Type', 'application/json')
  httpClient.method('POST'),
  httpClient.parseJSON(),
  httpClient.json({ foo: 'bar' }),
  httpClient.base('https://api.example.com/foo/bar')
)

createFooBar().then(response => response.jsonData)
```

At the moment this produces a URL like this (see `undefined` at the end of the string):

```
https://api.example.com/foo/barundefined
```