### PR TITLE
clarify webpack setup in readme add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 umd
+node_modules

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In node, http-client automatically uses the [node-fetch](https://github.com/biti
 
 You'll need to shim `window.fetch` in [browsers that do not support it](http://caniuse.com/#feat=fetch) (Safari and IE). [github/fetch](https://github.com/github/fetch) is a great polyfill.
 
-If you're bundling http-client with [webpack](https://webpack.github.io/), you'll want to include the following in your webpack config:
+If you're bundling http-client with [webpack](https://webpack.github.io/), you'll want to include the following in your client's webpack config:
 
 ```js
 const webpack = require('webpack')


### PR DESCRIPTION
I appreciate you adding the webpack setup instructions and wanted to send a simple PR clarifying it is for the client's webpack config, not server.

I am not sure if omitting node_modules from .gitignore was on purpose or not so I included it because it made it difficult to send the initial PR with 10k+ changes already listed. If this was on purpose/we should follow an alternative method, I think including that in https://github.com/mjackson/http-client/blob/master/CONTRIBUTING.md would help. (I don't think an update to CHANGES.md was necessary for this particular PR). Also, I thought the "Issues" note was helpful that was removed in https://github.com/mjackson/http-client/commit/efe43ddcf8742d1bac13cd4d90eb74bf8dc1bd51. Was that on purpose?