### PR TITLE
Feature/add catch errors middleware

### DIFF
--- a/modules/__tests__/catchErrors-test.js
+++ b/modules/__tests__/catchErrors-test.js
@@ -1,0 +1,38 @@
+import expect from 'expect'
+import { catchErrors } from '../index'
+
+const echo = (input, options) =>
+  Promise.resolve({ input, options })
+
+describe('catchErrors', () => {
+  it('do notthing for normal request', () => {
+    expect(() => {
+      catchErrors()(echo, 'url', {
+        method: 'post',
+        body: JSON.stringify({ name: 'catchErrors' })
+      })
+    }).toNotThrow()
+  })
+
+  describe('when the options has a data property', () => {
+    it('throws an error', () =>
+      expect(() => {
+        catchErrors()(echo, 'url', {
+          method: 'post',
+          data: JSON.stringify({ name: 'catchErrors' })
+        })
+      }).toThrow(/Did you try to use 'body:/)
+    )
+  })
+
+  describe('when the options has a POJO body property', () => {
+    it('throws an error', () =>
+      expect(() => {
+        catchErrors()(echo, 'url', {
+          method: 'post',
+          body: { name: 'catchErrors' }
+        })
+      }).toThrow(/Did you forgot to 'JSON\.stringify/)
+    )
+  })
+})

--- a/modules/index.js
+++ b/modules/index.js
@@ -163,6 +163,59 @@ export const params = (object) => {
 }
 
 /**
+ * Check agains the final input and options to check if there's missing/misconfigured
+ * properties.
+ */
+export const catchErrors = () => {
+  function checkOptions(input, options) {
+    [
+      {
+        name: 'data',
+        validate: (input, options) => {
+          const verb = (options.method || 'GET').toUpperCase()
+          if (verb === 'GET' || verb === 'HEAD') {
+            return
+          }
+          throw new Error(`Did you try to use 'body: ${JSON.stringify(options.data)}'?`)
+        }
+      },
+      {
+        name: 'body',
+        validate: (input, options) => {
+          const verb = (options.method || 'GET').toUpperCase()
+          if (verb === 'GET' || verb === 'HEAD') {
+            return
+          }
+          function isPojo(obj) {
+            // Just copy for now.
+            // https://github.com/nickb1080/is-pojo/blob/master/lib/index.js
+            if (obj === null || typeof obj !== 'object') {
+              return false
+            }
+            return Object.getPrototypeOf(obj) === Object.prototype
+          }
+          // https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch#Parameters
+          if (isPojo(options.body)) {
+            throw new Error(`Did you forgot to 'JSON.stringify(${JSON.stringify(options.body)})'`)
+          }
+        }
+      }
+    ].forEach(({ name, validate }) => {
+      if (name in options) {
+        validate(input, options)
+      }
+    })
+  }
+
+
+  return (fetch, input, options = {}) => {
+    checkOptions(input, options)
+
+    return fetch(input, options)
+  }
+}
+
+/**
  * A helper for creating middleware that handles a successful response.
  */
 export const onResponse = (handler) =>


### PR DESCRIPTION
## Description

Add `catchError` middleware to validate `options` object. It may be very useful **in development**. Let me know what you think. Please note that the code is _not well organized_. Just want to get a first version and your feedback.

## TODOs

* [ ] Update ` CHANGES.md`
* [ ] Add `process.env.NODE_ENV` check
* [ ] Clean up the code to match the general style of this project.

## References

* https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch#Parameters