### PR TITLE
Fix Content-Length header for non-ASCII body

### DIFF
--- a/modules/__tests__/body-test.js
+++ b/modules/__tests__/body-test.js
@@ -4,24 +4,26 @@ import { body } from '../index'
 const echo = (input, options) =>
   Promise.resolve({ input, options })
 
+const str = 'hello λ world'
+
 describe('body', () => {
   it('sets the body of the request', () => {
-    body('hello world')(echo).then(({ options }) =>
-      expect(options.body).toEqual('hello world')
+    body(str)(echo).then(({ options }) =>
+      expect(options.body).toEqual(str)
     )
   })
 
   describe('when the content has a length property', () => {
     it('sets the Content-Length request header', () =>
-      body('hello world')(echo).then(({ options }) =>
-        expect(options.headers['Content-Length']).toEqual('hello world'.length)
+      body(str)(echo).then(({ options }) =>
+        expect(options.headers['Content-Length']).toEqual(Buffer.byteLength(str))
       )
     )
   })
 
   describe('when the contentType argument is given', () => {
     it('sets the Content-Type request header', () =>
-      body('hello world', 'text/plain')(echo).then(({ options }) =>
+      body(str, 'text/plain')(echo).then(({ options }) =>
         expect(options.headers['Content-Type']).toEqual('text/plain')
       )
     )

--- a/modules/__tests__/body-test.js
+++ b/modules/__tests__/body-test.js
@@ -1,5 +1,6 @@
 import expect from 'expect'
 import { body } from '../index'
+import byteLength from 'byte-length'
 
 const echo = (input, options) =>
   Promise.resolve({ input, options })
@@ -16,7 +17,7 @@ describe('body', () => {
   describe('when the content has a length property', () => {
     it('sets the Content-Length request header', () =>
       body(str)(echo).then(({ options }) =>
-        expect(options.headers['Content-Length']).toEqual(Buffer.byteLength(str))
+        expect(options.headers['Content-Length']).toEqual(byteLength(str))
       )
     )
   })

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,4 +1,5 @@
 import { stringify } from 'query-string'
+import byteLength from 'byte-length'
 
 const stringifyQuery = (query) =>
   (typeof query === 'string' ? query : stringify(query))
@@ -131,7 +132,7 @@ export const body = (content, contentType) =>
     options.body = content
 
     if (content.length != null)
-      setHeader(options, 'Content-Length', Buffer.byteLength(content))
+      setHeader(options, 'Content-Length', byteLength(content))
 
     if (contentType)
       setHeader(options, 'Content-Type', contentType)

--- a/modules/index.js
+++ b/modules/index.js
@@ -131,7 +131,7 @@ export const body = (content, contentType) =>
     options.body = content
 
     if (content.length != null)
-      setHeader(options, 'Content-Length', content.length)
+      setHeader(options, 'Content-Length', Buffer.byteLength(content))
 
     if (contentType)
       setHeader(options, 'Content-Type', contentType)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "npm run lint && karma start"
   },
   "dependencies": {
+    "byte-length": "^0.1.1",
     "query-string": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Today I have problem with the content-length of data in Chinese when using `http-client`.

So I made some modification.

I am not sure if I should add `buffer` to the dependencies because `webpack` uses an older but working version of it.