### PR TITLE
Change default 'as' for parse middleware to 'decodedBody'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [v5.0.0]
+> TBD
+
+- Change default 'as' for the parse middleware to prevent returning `Response#body` (a `ReadableStream` without a 
+`body` property) as the response
+
 ## [v4.3.0]
 > Sep 30, 2016
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ import { createFetch, base, accept, parse } from 'http-client'
 const fetch = createFetch(
   base('https://api.stripe.com/v1'),  // Prefix all request URLs
   accept('application/json'),         // Set "Accept: application/json" in the request headers
-  parse('json')                       // Read the response as JSON and put it in response.body
+  parse('json')                       // Read the response as JSON and put it in response.decodedBody
 )
 
 fetch('/customers/5').then(response => {
@@ -200,9 +200,10 @@ const fetch = createFetch(
 )
 ```
 
-#### `parse(parser, as = 'body')`
+#### `parse(parser, as = 'decodedBody')`
 
-Reads the response body to completion, parses the response, and puts the result on `response.body` (or whatever `as` is). `parser` must be the name of a valid [Body](https://developer.mozilla.org/en-US/docs/Web/API/Body) parsing method. The following parsers are available in [the spec](https://fetch.spec.whatwg.org/#body-mixin):
+Reads the response body to completion, parses the response, and puts the result in `response.decodedBody` (or 
+whatever `as` is). `parser` must be the name of a valid [Body](https://developer.mozilla.org/en-US/docs/Web/API/Body) parsing method. The following parsers are available in [the spec](https://fetch.spec.whatwg.org/#body-mixin):
 
 - `arrayBuffer`
 - `blob`
@@ -218,7 +219,7 @@ const fetch = createFetch(
 )
 
 fetch(input).then(response => {
-  console.log(response.body)
+  console.log(response.decodedBody)
 })
 ```
 

--- a/modules/__tests__/body-test.js
+++ b/modules/__tests__/body-test.js
@@ -11,7 +11,7 @@ describe('body', () => {
 
     it('sets the body of the request', () => {
       body(asciiString)(echo).then(({ options }) =>
-        expect(options.body).toEqual(asciiString)
+        expect(options.decodedBody).toEqual(asciiString)
       )
     })
 
@@ -37,7 +37,7 @@ describe('body', () => {
 
     it('sets the body of the request', () => {
       body(multiByteString)(echo).then(({ options }) =>
-        expect(options.body).toEqual(multiByteString)
+        expect(options.decodedBody).toEqual(multiByteString)
       )
     })
 

--- a/modules/__tests__/json-test.js
+++ b/modules/__tests__/json-test.js
@@ -7,7 +7,7 @@ const echo = (input, options) =>
 describe('json', () => {
   it('sets the body of the request to JSON', () => {
     json({ hello: 'world' })(echo).then(({ options }) =>
-      expect(options.body).toEqual('{"hello":"world"}')
+      expect(options.decodedBody).toEqual('{"hello":"world"}')
     )
   })
 

--- a/modules/__tests__/params-test.js
+++ b/modules/__tests__/params-test.js
@@ -16,7 +16,7 @@ describe('params', () => {
   describe('when used with a POST request', () => {
     it('sets the body of the request to a URL-encoded version of the object', () => {
       params({ hello: 'world' })(echo, '/', { method: 'POST' }).then(({ options }) =>
-        expect(options.body).toEqual('hello=world')
+        expect(options.decodedBody).toEqual('hello=world')
       )
     })
 

--- a/modules/__tests__/parseJSON-test.js
+++ b/modules/__tests__/parseJSON-test.js
@@ -11,7 +11,7 @@ describe('parse("json")', () => {
   describe('by default', () => {
     it('sets the body property of the response', () =>
       parse('json')(echoJSON({ hello: 'world' })).then(response =>
-        expect(response.body).toEqual({ hello: 'world' })
+        expect(response.decodedBody).toEqual({ hello: 'world' })
       )
     )
   })

--- a/modules/__tests__/parseText-test.js
+++ b/modules/__tests__/parseText-test.js
@@ -11,7 +11,7 @@ describe('parse("text")', () => {
   describe('by default', () => {
     it('sets the body property of the response', () =>
       parse('text')(echoText('hello world')).then(response =>
-        expect(response.body).toEqual('hello world')
+        expect(response.decodedBody).toEqual('hello world')
       )
     )
   })

--- a/modules/index.js
+++ b/modules/index.js
@@ -200,7 +200,7 @@ export const onResponse = recv
  * Reads the response stream to completion, parses its content
  * using the given parser, and adds the result to response.body.
  */
-export const parse = (parser, as = 'body') =>
+export const parse = (parser, as = 'decodedBody') =>
   recv(response => {
     if (as in response)
       return response[as]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-client",
-  "version": "4.3.1",
+  "version": "5.0.0",
   "description": "Compose HTTP clients using JavaScript's fetch API",
   "repository": "mjackson/http-client",
   "author": "Michael Jackson",


### PR DESCRIPTION
- Prevents the default parse approach from returning `Response#body` (a `ReadableStream` without a  `body` property) as the response
- Bumped major version because this is a backwards-incompatible change for people using the default value of 'as' with parse()
- Fixes #34