### PR TITLE
(docs/test): use cross-fetch instead of isomorphic-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using [npm](https://www.npmjs.com/):
 
     $ npm install --save http-client
 
-http-client requires you to bring your own [global `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch) function (for convenience when using the top-level `createFetch` function). [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) is a great polyfill if you need to support environments that don't already have a global `fetch` function.
+http-client requires you to bring your own [global `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch) function (for convenience when using the top-level `createFetch` function). [cross-fetch](https://github.com/lquixada/cross-fetch) is a great polyfill if you need to support environments that don't already have a global `fetch` function.
 
 Then, use as you would anything else:
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "expect": "^1.14.0",
     "gzip-size": "^3.0.0",
     "in-publish": "^2.0.0",
-    "isomorphic-fetch": "^2.2.1",
+    "cross-fetch": "^3.0.4",
     "karma": "^1.1.2",
     "karma-browserstack-launcher": "^1.0.1",
     "karma-chrome-launcher": "^2.0.0",

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,5 +1,5 @@
 require('es6-promise').polyfill()
-require('isomorphic-fetch')
+require('cross-fetch/polyfill')
 
 const context = require.context('./modules', true, /-test\.js$/)
 context.keys().forEach(context)


### PR DESCRIPTION
- Per the cross-fetch FAQ (https://github.com/lquixada/cross-fetch#why-not-isomorphic-fetch),
  isomorphic-fetch has issues with RN, hasn't been maintained in years,
  and has outdated dependencies
  - cross-fetch hasn't been maintained in some months now too though,
    but only a few unresolved issues/PRs